### PR TITLE
Fix duplicating chunk entities

### DIFF
--- a/src/voxel/world/chunks.rs
+++ b/src/voxel/world/chunks.rs
@@ -45,18 +45,15 @@ fn update_view_chunks(
                     continue;
                 }
 
-                let chunk_key = {
-                    let mut pos: IVec3 = player_pos.chunk_min
-                        + IVec3::new(
-                            x * CHUNK_LENGTH as i32,
-                            y * CHUNK_LENGTH as i32,
-                            z * CHUNK_LENGTH as i32,
-                        );
-
-                    pos.y = pos.y.max(0);
-
-                    pos
-                };
+                let chunk_key = player_pos.chunk_min
+                    + IVec3::new(
+                        x * CHUNK_LENGTH as i32,
+                        y * CHUNK_LENGTH as i32,
+                        z * CHUNK_LENGTH as i32,
+                    );
+                if chunk_key.y < 0 {
+                    continue;
+                }
 
                 if chunk_entities.entity(chunk_key).is_none() {
                     chunk_command_queue.create.push(chunk_key);


### PR DESCRIPTION
Because `y` was normalized here, we could add many `chunk_key`s to the command queue with the same position. The duplicated chunks would also never be unloaded as the mapping was overwritten in `ChunkEntities`. This could lead to huge slowdown when flying around/spamming 'Clear Loaded Chunks'